### PR TITLE
改进显示Spotify菜单代码并修复不工作的页面

### DIFF
--- a/doulist.js
+++ b/doulist.js
@@ -1,4 +1,4 @@
-var qpath = 'http://ws.spotify.com/search/1/album.json', albumsInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/album.json',
 isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
@@ -9,18 +9,17 @@ var spotifyPage = function () {
             var itemCon = $(this), album = $(this).find('.pl2>a').text(),
             info = $(this).find('p.pl').text().match('^表演者 : (.+)出版者 :.+$'),
             artist = (info && info.length > 1) ? info[1] : '';
-            $.ajax({url:qpath, 
+            $.ajax({url:qpath,
                     crossDomain:true,
                     data:{q:album.concat(' artist:', artist)},
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('.pl2'), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('.pl2'), q, menuLeft, ret.albums);
                         }
                     }
                    });
-        });    
+        });
 };
 
 chrome.extension.sendRequest({method:"getLocalStorage", key:"isOpenSpotifyDirect"},

--- a/fm.js
+++ b/fm.js
@@ -1,50 +1,20 @@
-var qpath = 'http://ws.spotify.com/search/1/track.json', tracksInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/track.json',
 isOpenSpotifyDirect = null;
-
-var spotifyMenu,
-showSpotifyMenu = function (con) {
-    if (!spotifyMenu) {
-        var menuLeft = $('#record_viewer').offset().left - 256; // menu width
-        spotifyMenu = $('<div id="spotify-items"></div>').appendTo('body').css('left', menuLeft);
-    }
-    var tracks = tracksInfo[$(con).attr('data-q')];
-    spotifyMenu.empty();
-    $.each(tracks, function (idx, track) {
-               var link = isOpenSpotifyDirect ? track.href : 'http://open.spotify.com/track/'.concat(track.href.split(':')[2]),
-               target = isOpenSpotifyDirect ? '' : '_blank';
-               $('<a class="spotify-item" href="'.concat(link, '" target="', target, '"><span>', track.name, ' - ', track.artists[0].name, '</span></a>'))
-                   .appendTo(spotifyMenu).hover(
-                       function () {
-                           $(this).addClass('mover');
-                       }, function () {
-                           $(this).removeClass('mover');
-                       });
-           });
-    return spotifyMenu.css({top:con.offset().top});
-};
-
-var addSpotifyBtn = function (con, q) {
-    var link = '';
-    $('<span title="Albums on Spotify" class="spotify-btn" data-q="'.concat(q, '">▸</span>')).appendTo($(con))
-        .mouseenter(function () {
-                        showSpotifyMenu($(this));
-                    });
-};
 
 var main = function () {
     $('#record_viewer .props').each(
         function () {
             var nameCon = $(this).children('.song_title'), name = nameCon.text(),
             artist = $(this).children('.performer').text(),
-            q = name.concat(' artist:', artist);
-            $.ajax({url:qpath, 
+            q = name.concat(' artist:', artist),
+            menuLeft = $('#record_viewer').offset().left - 256;
+            $.ajax({url:qpath,
                     crossDomain:true,
                     data:{q:q},
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            tracksInfo[q] = ret.tracks;
-                            addSpotifyBtn(nameCon, q);
+                            addSpotifyBtn(nameCon, q, menuLeft, ret.tracks);
                         }
                     }
                    });
@@ -54,5 +24,5 @@ var main = function () {
 chrome.extension.sendRequest({method:"getLocalStorage", key:"isOpenSpotifyDirect"},
                              function(response) {
                                  isOpenSpotifyDirect = (response.data == 'false') ? false : true;
-                                 main();
+                                 setTimeout(main, 1500);
                              });

--- a/front_guess_page.js
+++ b/front_guess_page.js
@@ -1,5 +1,5 @@
 var qpath = 'http://ws.spotify.com/search/1/album.json',
-albumsInfo = {}, isOpenSpotifyDirect = null;
+isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
     var subjectsCon = $('.guess3-list'),
@@ -15,8 +15,7 @@ var spotifyPage = function () {
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('div.rating'), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('div.rating'), q, menuLeft, ret.albums);
                         }
                     }
                    });

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "豆瓣Spotify助手",
-  "version": "1.26",
+  "version": "1.28",
   "description": "在豆瓣上开一扇通往Spotify的窗",
   "manifest_version": 2,
   "browser_action": {
@@ -72,7 +72,7 @@
      {
        "matches": ["http://douban.fm/mine*"],
        "run_at": "document_end",
-       "js": ["jquery-1.7.1.min.js", "fm.js"],
+       "js": ["jquery-1.7.1.min.js", "utils.js", "fm.js"],
        "all_frames": true
      },
      {

--- a/omni_search_page.js
+++ b/omni_search_page.js
@@ -1,17 +1,16 @@
 var qpath = 'http://ws.spotify.com/search/1/album.json'
-, albumsInfo = {}
-, isOpenSpotifyDirect = null
+, isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
     var subjectsCon = $('.result-list')
-    , menuLeft = subjectsCon.offset().left + subjectsCon.width() + 10
+    , menuLeft = subjectsCon.offset().left + subjectsCon.width() + 10;
 
     $(".result:has(a.nbg[href*=music]):not(:has(span.spotify-btn))").each(
         function (index) {
             var itemCon = $(this)
-	    , albumName = $(this).find('.title h3 a').text()
-	    , artistInfos = $(this).find('.rating-info .subject-cast').text().split('/')
-            , artistName = artistInfos[0]
+	        , albumName = $(this).find('.title h3 a').text()
+	        , artistInfos = $(this).find('.rating-info .subject-cast').text().split('/')
+            , artistName = artistInfos[0];
 
             $.ajax({url:qpath,
                     crossDomain:true,
@@ -19,23 +18,21 @@ var spotifyPage = function () {
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('.title h3'), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('.title h3'), q, menuLeft, ret.albums);
                         }
                     }
                    });
         });
 };
 
-chrome.extension.sendRequest({method:"getLocalStorage", key:"isOpenSpotifyDirect"},
-                             function(response) {
-                                 isOpenSpotifyDirect = (response.data == 'false') ? false : true;
-                                 spotifyPage();
-				 
-				 var refresh_interval = 850;
-
-				 $(".result-list-ft:has(a[data-subtype=item])").delegate("a", "click", function() {
-				     setTimeout(spotifyPage, refresh_interval);
-				 });
-
-                             });
+chrome.extension.sendRequest(
+    {method:"getLocalStorage", key:"isOpenSpotifyDirect"},
+    function(response) {
+        isOpenSpotifyDirect = (response.data == 'false') ? false : true;
+        spotifyPage();
+		var refresh_interval = 850;
+		$(".result-list-ft:has(a[data-subtype=item])").delegate(
+            "a", "click", function() {
+				setTimeout(spotifyPage, refresh_interval);
+			});
+    });

--- a/page.js
+++ b/page.js
@@ -1,4 +1,4 @@
-var qpath = 'http://ws.spotify.com/search/1/album.json', albumsInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/album.json',
 isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
@@ -9,18 +9,17 @@ var spotifyPage = function () {
             var itemCon = $(this), album = $(this).find('.title>a>em').text(),
             infos = $(this).find('.intro').text().split('/'),
             artist = infos[infos.length - 1].replace(' ', '');;
-            $.ajax({url:qpath, 
+            $.ajax({url:qpath,
                     crossDomain:true,
                     data:{q:album.concat(' artist:', artist)},
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('.title'), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('.title'), q, menuLeft, ret.albums);
                         }
                     }
                    });
-        });    
+        });
 };
 
 chrome.extension.sendRequest({method:"getLocalStorage", key:"isOpenSpotifyDirect"},

--- a/programme.js
+++ b/programme.js
@@ -1,4 +1,4 @@
-var qpath = 'http://ws.spotify.com/search/1/track.json', albumsInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/track.json',
 isOpenSpotifyDirect = null;
 
 var spotifyPage = function(){
@@ -16,8 +16,7 @@ var spotifyPage = function(){
                 success:function (ret) {
                     if (ret.info.num_results && ret.info.num_results > 0) {
                         var q = ret.info.query;
-                        albumsInfo[q] = ret.tracks;
-                        addSpotifyBtn($(info).find('.song-info'), q, menuLeft);
+                        addSpotifyBtn($(info).find('.song-info'), q, menuLeft, ret.tracks);
                     }
                 }
             });

--- a/rdio.js
+++ b/rdio.js
@@ -1,5 +1,5 @@
 var qpath = 'http://ws.spotify.com/search/1/album.json',
-albumsInfo = {}, isOpenSpotifyDirect = null;
+isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
     var subjectsCon = $('.main_content'),
@@ -15,8 +15,7 @@ var spotifyPage = function () {
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(meta.find('a.album_title'), q, menuLeft);
+                            addSpotifyBtn(meta.find('a.album_title'), q, menuLeft, ret.albums);
                         }
                     }
                    });

--- a/search_page.js
+++ b/search_page.js
@@ -1,4 +1,4 @@
-var qpath = 'http://ws.spotify.com/search/1/album.json', albumsInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/album.json',
 isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
@@ -15,8 +15,7 @@ var spotifyPage = function () {
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('.pl2 a').first(), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('.pl2 a').first(), q, menuLeft, ret.albums);
                         }
                     }
                    });

--- a/tag.js
+++ b/tag.js
@@ -1,4 +1,4 @@
-var qpath = 'http://ws.spotify.com/search/1/album.json', albumsInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/album.json',
 isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
@@ -16,12 +16,11 @@ var spotifyPage = function () {
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('.pl2'), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('.pl2'), q, menuLeft, ret.albums);
                         }
                     }
                    });
-        });    
+        });
 };
 
 chrome.extension.sendRequest({method:"getLocalStorage", key:"isOpenSpotifyDirect"},

--- a/update_page.js
+++ b/update_page.js
@@ -1,4 +1,4 @@
-var qpath = 'http://ws.spotify.com/search/1/album.json', albumsInfo = {},
+var qpath = 'http://ws.spotify.com/search/1/album.json',
 isOpenSpotifyDirect = null;
 
 var spotifyPage = function () {
@@ -14,8 +14,7 @@ var spotifyPage = function () {
                     success:function (ret) {
                         if (ret.info.num_results && ret.info.num_results > 0) {
                             var q = ret.info.query;
-                            albumsInfo[q] = ret.albums;
-                            addSpotifyBtn(itemCon.find('.title'), q, menuLeft);
+                            addSpotifyBtn(itemCon.find('.title'), q, menuLeft, ret.albums);
                         }
                     }
                    });

--- a/utils.js
+++ b/utils.js
@@ -1,29 +1,29 @@
-var albumsMenu,
-showAlbumsMenu = function (con, menuLeft) {
-    if (!albumsMenu) {
-        albumsMenu = $('<div id="spotify-items"></div>').appendTo('body').css('left', menuLeft);
+var itemsMenu,
+showItemsMenu = function (con, menuLeft, items) {
+    if (!itemsMenu) {
+        itemsMenu = $('<div id="spotify-items"></div>').appendTo('body').css('left', menuLeft);
     }
-    var albums = albumsInfo[$(con).attr('data-q')];
-    // add albums
-    albumsMenu.empty();
-    $.each(albums, function (idx, album) {
-               var link = isOpenSpotifyDirect ? album.href : 'http://open.spotify.com/album/'.concat(album.href.split(':')[2]),
+    itemsMenu.empty();
+    $.each(items, function (idx, item) {
+               var itemInfo = item.href.split(':'),
+               link = isOpenSpotifyDirect ? item.href :
+                   'http://open.spotify.com/'.concat(itemInfo[1], '/', itemInfo[2]),
                target = isOpenSpotifyDirect ? '' : '_blank';
-               $('<a class="spotify-item" href="'.concat(link, '" target="', target, '"><span>', album.name, ' - ', album.artists[0].name, '</span></a>'))
-                   .appendTo(albumsMenu).hover(
+               $('<a class="spotify-item" href="'.concat(link, '" target="', target, '"><span>', item.name, ' - ', item.artists[0].name, '</span></a>'))
+                   .appendTo(itemsMenu).hover(
                        function () {
                            $(this).addClass('mover');
                        }, function () {
                            $(this).removeClass('mover');
                        });
            });
-    return albumsMenu.css({top:con.offset().top});
+    return itemsMenu.css({top:con.offset().top});
 },
 
-addSpotifyBtn = function (con, q, menuLeft) {
+addSpotifyBtn = function (con, q, menuLeft, items) {
     var link = '';
-    $('<span title="Albums on Spotify" class="spotify-btn" data-q="'.concat(q, '">▸</span>')).appendTo(con)
+    $('<span title="Items on Spotify" class="spotify-btn" data-q="'.concat(q, '">▸</span>')).appendTo(con)
         .mouseenter(function () {
-                        showAlbumsMenu($(this), menuLeft);
+                        showItemsMenu($(this), menuLeft, items);
                     });
 };


### PR DESCRIPTION
之前总有一个albumsInfo做为content script和utils.js之间调用addSpotifyBtn的全局变量，其实没必要，作为参数就够了。
另外修复了电台mine页面。
